### PR TITLE
Fix compile with opus-1.3.1 and emscripten-2.0.17

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,5 @@
 # usage: ./build.sh [flags]
 # asm.js release flags: -O2 --memory-init-file 0
 # wasm release flags: -O2 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1
-em++ api.cpp -Iopus/include -Lopus/.libs -lopus --pre-js preapi.js --post-js api.js $@ -o libopus.js
+em++ api.cpp -Iopus/include -Lopus/.libs -lopus --pre-js preapi.js \
+  --post-js api.js -s EXPORTED_FUNCTIONS='["_free"]' $@ -o libopus.js

--- a/opus/build.sh
+++ b/opus/build.sh
@@ -6,11 +6,12 @@ git remote add origin https://github.com/xiph/opus.git
 git pull
 
 # version
-git checkout v1.2.1
+git checkout v1.3.1
 
 # build lib
 ./autogen.sh
-emconfigure ./configure --disable-rtcd --disable-intrinsics --disable-shared --enable-static
+emconfigure ./configure --disable-rtcd --disable-intrinsics --disable-shared \
+  --enable-static  --disable-stack-protector --disable-hardening
 emmake make -j$(nproc)
 
 # should ouput libopus.a in .libs/ that is linkable with emcc


### PR DESCRIPTION
- Use latest stable upstream opus-1.3.1.

- Disable default build options not supported by emscripten
  (--disable-stack-protector --disable-hardening).

- Fix runtime error `_free is not a function`.
  Emscripten no longer exports _free by default, so explicitly export it.